### PR TITLE
fix(respond): increase MaxDataGramSize and suppress begin EOF on deflate close

### DIFF
--- a/respond/respond.go
+++ b/respond/respond.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 
@@ -21,7 +22,7 @@ const (
 	PortDefault = 1001
 
 	// maximum receivable size
-	MaxDataGramSize = 16384
+	MaxDataGramSize = 8192
 )
 
 // Response of the respond request
@@ -59,12 +60,12 @@ func (res *Response) parse(customFields []CustomFieldConfig) (*data.ResponseData
 	deflater := flate.NewReader(bytes.NewReader(res.Raw))
 	defer func() {
 		if err := deflater.Close(); err != nil && err != io.ErrUnexpectedEOF {
-			log.WithError(err).Error("failed to close uncompression")
+			log.WithError(err).WithField("node", res.Address).Error("failed to close uncompression")
 		}
 	}()
 	jsonData, err := io.ReadAll(deflater)
 	if err != nil && err != io.ErrUnexpectedEOF {
-		return nil, err
+		return nil, fmt.Errorf("node %s: %w", res.Address, err)
 	}
 
 	// Unmarshal

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -59,7 +59,7 @@ func (res *Response) parse(customFields []CustomFieldConfig) (*data.ResponseData
 	// Deflate
 	deflater := flate.NewReader(bytes.NewReader(res.Raw))
 	defer func() {
-		if err := deflater.Close(); err != nil && err != io.ErrUnexpectedEOF {
+		if err := deflater.Close(); err != nil {
 			log.WithError(err).WithField("node", res.Address).Error("failed to close uncompression")
 		}
 	}()

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -21,7 +21,7 @@ const (
 	PortDefault = 1001
 
 	// maximum receivable size
-	MaxDataGramSize = 65535
+	MaxDataGramSize = 16384
 )
 
 // Response of the respond request

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -21,7 +21,7 @@ const (
 	PortDefault = 1001
 
 	// maximum receivable size
-	MaxDataGramSize = 8192
+	MaxDataGramSize = 65535
 )
 
 // Response of the respond request
@@ -58,7 +58,7 @@ func (res *Response) parse(customFields []CustomFieldConfig) (*data.ResponseData
 	// Deflate
 	deflater := flate.NewReader(bytes.NewReader(res.Raw))
 	defer func() {
-		if err := deflater.Close(); err != nil {
+		if err := deflater.Close(); err != nil && err != io.ErrUnexpectedEOF {
 			log.WithError(err).Error("failed to close uncompression")
 		}
 	}()

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -22,7 +22,7 @@ const (
 	PortDefault = 1001
 
 	// maximum receivable size
-	MaxDataGramSize = 8192
+	MaxDataGramSize = 32768
 )
 
 // Response of the respond request

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -22,7 +22,7 @@ const (
 	PortDefault = 1001
 
 	// maximum receivable size
-	MaxDataGramSize = 32768
+	MaxDataGramSize = 65536
 )
 
 // Response of the respond request


### PR DESCRIPTION
Nodes with many neighbours or interfaces can send UDP responses larger than the previous 8192 byte limit, causing silent truncation and corrupt DEFLATE streams. Raise MaxDataGramSize to 65535 (UDP maximum) to prevent data loss.

Additionally, suppress io.ErrUnexpectedEOF in the deferred deflater.Close call: the announced daemon omits the DEFLATE final-block marker, so Close always returns this error even when all data was read successfully. The ReadAll call already ignores it; the Close log entry was a false positive.
